### PR TITLE
fix: saved terminal status corruption

### DIFF
--- a/_example/exec-command/main.go
+++ b/_example/exec-command/main.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"os/exec"
 
-	prompt "github.com/StepY1aoZz/go-prompt"
+	prompt "github.com/openGemini/go-prompt"
 )
 
 func executor(t string) {

--- a/_example/http-prompt/main.go
+++ b/_example/http-prompt/main.go
@@ -10,7 +10,7 @@ import (
 	"path"
 	"strings"
 
-	prompt "github.com/StepY1aoZz/go-prompt"
+	prompt "github.com/openGemini/go-prompt"
 )
 
 type RequestContext struct {

--- a/_example/live-prefix/main.go
+++ b/_example/live-prefix/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/StepY1aoZz/go-prompt"
+	prompt "github.com/openGemini/go-prompt"
 )
 
 var LivePrefixState struct {

--- a/_example/simple-echo/cjk-cyrillic/main.go
+++ b/_example/simple-echo/cjk-cyrillic/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/StepY1aoZz/go-prompt"
+	prompt "github.com/openGemini/go-prompt"
 )
 
 func executor(in string) {

--- a/_example/simple-echo/main.go
+++ b/_example/simple-echo/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	prompt "github.com/StepY1aoZz/go-prompt"
+	prompt "github.com/openGemini/go-prompt"
 )
 
 func completer(in prompt.Document) []prompt.Suggest {

--- a/_tools/complete_file/main.go
+++ b/_tools/complete_file/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	prompt "github.com/StepY1aoZz/go-prompt"
-	"github.com/StepY1aoZz/go-prompt/completer"
+	prompt "github.com/openGemini/go-prompt"
+	"github.com/openGemini/go-prompt/completer"
 )
 
 var filePathCompleter = completer.FilePathCompleter{

--- a/_tools/vt100_debug/main.go
+++ b/_tools/vt100_debug/main.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"syscall"
 
-	prompt "github.com/StepY1aoZz/go-prompt"
-	"github.com/StepY1aoZz/go-prompt/internal/term"
+	prompt "github.com/openGemini/go-prompt"
+	"github.com/openGemini/go-prompt/internal/term"
 )
 
 func main() {

--- a/buffer.go
+++ b/buffer.go
@@ -3,7 +3,7 @@ package prompt
 import (
 	"strings"
 
-	"github.com/StepY1aoZz/go-prompt/internal/debug"
+	"github.com/openGemini/go-prompt/internal/debug"
 )
 
 // Buffer emulates the console buffer.

--- a/completer/file.go
+++ b/completer/file.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"runtime"
 
-	prompt "github.com/StepY1aoZz/go-prompt"
-	"github.com/StepY1aoZz/go-prompt/internal/debug"
+	prompt "github.com/openGemini/go-prompt"
+	"github.com/openGemini/go-prompt/internal/debug"
 )
 
 var (

--- a/completion.go
+++ b/completion.go
@@ -3,8 +3,8 @@ package prompt
 import (
 	"strings"
 
-	"github.com/StepY1aoZz/go-prompt/internal/debug"
 	runewidth "github.com/mattn/go-runewidth"
+	"github.com/openGemini/go-prompt/internal/debug"
 )
 
 const (

--- a/document.go
+++ b/document.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/StepY1aoZz/go-prompt/internal/bisect"
-	istrings "github.com/StepY1aoZz/go-prompt/internal/strings"
 	runewidth "github.com/mattn/go-runewidth"
+	"github.com/openGemini/go-prompt/internal/bisect"
+	istrings "github.com/openGemini/go-prompt/internal/strings"
 )
 
 // Document has text displayed in terminal and cursor position.

--- a/emacs.go
+++ b/emacs.go
@@ -1,6 +1,6 @@
 package prompt
 
-import "github.com/StepY1aoZz/go-prompt/internal/debug"
+import "github.com/openGemini/go-prompt/internal/debug"
 
 /*
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/StepY1aoZz/go-prompt
+module github.com/openGemini/go-prompt
 
 go 1.14
 

--- a/input_posix.go
+++ b/input_posix.go
@@ -6,7 +6,7 @@ package prompt
 import (
 	"syscall"
 
-	"github.com/StepY1aoZz/go-prompt/internal/term"
+	"github.com/openGemini/go-prompt/internal/term"
 	"golang.org/x/sys/unix"
 )
 

--- a/internal/bisect/bisect_test.go
+++ b/internal/bisect/bisect_test.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/StepY1aoZz/go-prompt/internal/bisect"
+	"github.com/openGemini/go-prompt/internal/bisect"
 )
 
 func Example() {

--- a/internal/strings/strings_test.go
+++ b/internal/strings/strings_test.go
@@ -3,7 +3,7 @@ package strings_test
 import (
 	"fmt"
 
-	"github.com/StepY1aoZz/go-prompt/internal/strings"
+	"github.com/openGemini/go-prompt/internal/strings"
 )
 
 func ExampleIndexNotByte() {

--- a/internal/term/raw.go
+++ b/internal/term/raw.go
@@ -25,5 +25,5 @@ func SetRaw(fd int) error {
 	n.Cc[syscall.VMIN] = 1
 	n.Cc[syscall.VTIME] = 0
 
-	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(n))
+	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(&n))
 }

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -10,16 +10,18 @@ import (
 )
 
 var (
-	saveTermios     *unix.Termios
+	saveTermios     unix.Termios
 	saveTermiosFD   int
 	saveTermiosOnce sync.Once
 )
 
-func getOriginalTermios(fd int) (*unix.Termios, error) {
+func getOriginalTermios(fd int) (unix.Termios, error) {
 	var err error
 	saveTermiosOnce.Do(func() {
 		saveTermiosFD = fd
-		saveTermios, err = termios.Tcgetattr(uintptr(fd))
+		var saveTermiosPtr *unix.Termios
+		saveTermiosPtr, err = termios.Tcgetattr(uintptr(fd))
+		saveTermios = *saveTermiosPtr
 	})
 	return saveTermios, err
 }
@@ -30,5 +32,5 @@ func Restore() error {
 	if err != nil {
 		return err
 	}
-	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, o)
+	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, &o)
 }

--- a/prompt.go
+++ b/prompt.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/StepY1aoZz/go-prompt/internal/debug"
+	"github.com/openGemini/go-prompt/internal/debug"
 )
 
 // Executor is called when user input something text.

--- a/render.go
+++ b/render.go
@@ -3,8 +3,8 @@ package prompt
 import (
 	"runtime"
 
-	"github.com/StepY1aoZz/go-prompt/internal/debug"
 	runewidth "github.com/mattn/go-runewidth"
+	"github.com/openGemini/go-prompt/internal/debug"
 )
 
 // Render to render prompt information from state of Buffer.

--- a/signal_posix.go
+++ b/signal_posix.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/StepY1aoZz/go-prompt/internal/debug"
+	"github.com/openGemini/go-prompt/internal/debug"
 )
 
 func (p *Prompt) handleSignals(exitCh chan int, winSizeCh chan *WinSize, stop chan struct{}) {

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/StepY1aoZz/go-prompt/internal/debug"
+	"github.com/openGemini/go-prompt/internal/debug"
 )
 
 func (p *Prompt) handleSignals(exitCh chan int, winSizeCh chan *WinSize, stop chan struct{}) {


### PR DESCRIPTION
fix https://github.com/openGemini/openGemini/issues/594.

When the `saveTermios` variable (referring the original terminal state) is a pointer, it will be modified unexpectedly in function `SetRaw` (should be the original state, but becomes the modified 'raw' state), which leads to the `Restore` function not really working.